### PR TITLE
Update Karma launch to use 0.13.0 API changes

### DIFF
--- a/lib/server_process.js
+++ b/lib/server_process.js
@@ -1,5 +1,6 @@
 'use strict';
 
-var server = require('karma').server;
+var Server = require('karma').Server;
 var data = JSON.parse(process.argv[2]);
-server.start(data);
+var server = new Server(data);
+server.start();

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "gulp"
   },
   "dependencies": {
-    "karma": "*"
+    "karma": "> 0.13.0"
   },
   "devDependencies": {
     "gulp": "*",


### PR DESCRIPTION
Karma 0.13 changes the public API in a backwards incompatible manner. This pull request updates the server_process script to launch Karma with the new 0.13 API rather than the old API.
